### PR TITLE
Log exception when map fails to update

### DIFF
--- a/custom_components/roborock/camera.py
+++ b/custom_components/roborock/camera.py
@@ -182,7 +182,7 @@ class VacuumCamera(Camera):
         try:
             self._handle_map_data()
         except Exception as e:
-            _LOGGER.error(e)
+            _LOGGER.exception(e)
             self._set_map_data(
                 MapDataParserRoborock.create_empty(self._colors, str(self._status))
             )


### PR DESCRIPTION
Otherwise the stack trace is not logged and we can't figure out what's going south.