### PR TITLE
Handle cases where MQTT does not respond

### DIFF
--- a/custom_components/roborock/api.py
+++ b/custom_components/roborock/api.py
@@ -239,7 +239,7 @@ class RoborockMqttClient:
                 raise CommandVacuumError(method, response)
             return response
         except Empty as e:
-            return str(e)
+            return None
 
 
 class RoborockClient:

--- a/custom_components/roborock/camera.py
+++ b/custom_components/roborock/camera.py
@@ -205,7 +205,7 @@ class VacuumCamera(Camera):
         response = self._client.send_request(
             self._device.get("duid"), "get_map_v1", [], True
         )
-        if response is None:
+        if not response:
             return None, False
         map_stored = False
         if store_map_path is not None:

--- a/custom_components/roborock/vacuum.py
+++ b/custom_components/roborock/vacuum.py
@@ -71,9 +71,9 @@ class RoborockVacuum(StateVacuumEntity):
         )
 
     def update(self):
-        self._status = self.send("get_status")
-        if self._status is None:
-            self._status = {}
+        updatedStatus = self.send("get_status")
+        if updatedStatus:
+            self._status = updatedStatus
 
     @property
     def supported_features(self) -> int:


### PR DESCRIPTION
While this does not revive the communication channel, it does at least stop the log from getting spammed with errors every 5 seconds when the camera tries to update. The reason behind the exceptions was that when the response could not be returned from the queue, `send_request` returned an empty string instead when it tried to log the exception, as you can see in this small repro:

```Python
from queue import Queue, Empty

queue = Queue()
try:
    response = queue.get(timeout=0)
except Empty as e:
    print(f"'{e}'")
```

This should fix #21 and #23 for now.