### PR TITLE
Add strings for options

### DIFF
--- a/custom_components/roborock/translations/en.json
+++ b/custom_components/roborock/translations/en.json
@@ -13,5 +13,15 @@
       "no_device": "No device found within your Roborock account",
       "auth": "Failed to login. Check your credentials"
     }
+  },
+  "options": {
+    "step": {
+      "user": {
+        "data": {
+          "camera": "Integrate map as camera",
+          "vacuum": "Integrate as vacuum"
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
I had two mysterious checkboxes without labels, but now I know what they mean:
![image](https://user-images.githubusercontent.com/431167/208188513-702e6dbf-be6a-4536-ab1e-7d17a0055e84.png)

Feel free to tweak the phrasing.