### PR TITLE
Minor sensor/attribute fixes and naming update

### DIFF
--- a/custom_components/roborock/sensor.py
+++ b/custom_components/roborock/sensor.py
@@ -39,10 +39,10 @@ ATTR_CLEAN_SUMMARY_TOTAL_DURATION = "total_duration"
 ATTR_CLEAN_SUMMARY_TOTAL_AREA = "total_area"
 ATTR_CLEAN_SUMMARY_COUNT = "count"
 ATTR_CLEAN_SUMMARY_DUST_COLLECTION_COUNT = "dust_collection_count"
-ATTR_CONSUMABLE_STATUS_MAIN_BRUSH_LEFT = "main_brush_left"
-ATTR_CONSUMABLE_STATUS_SIDE_BRUSH_LEFT = "side_brush_left"
-ATTR_CONSUMABLE_STATUS_FILTER_LEFT = "filter_left"
-ATTR_CONSUMABLE_STATUS_SENSOR_DIRTY_LEFT = "sensor_dirty_left"
+ATTR_CONSUMABLE_STATUS_MAIN_BRUSH_REMAINING = "main_brush_remaining"
+ATTR_CONSUMABLE_STATUS_SIDE_BRUSH_REMAINING = "side_brush_remaining"
+ATTR_CONSUMABLE_STATUS_FILTER_REMAINING = "filter_remaining"
+ATTR_CONSUMABLE_STATUS_SENSOR_DIRTY_REMAINING = "sensor_dirty_remaining"
 
 
 @dataclass
@@ -122,6 +122,7 @@ VACUUM_SENSORS = {
         native_unit_of_measurement=AREA_SQUARE_METERS,
         icon="mdi:texture-box",
         key=StatusField.CLEAN_AREA,
+        value=lambda value: value / 1000000,
         parent_key=RoborockDevicePropField.STATUS,
         entity_category=EntityCategory.DIAGNOSTIC,
         name="Current clean area",
@@ -162,44 +163,44 @@ VACUUM_SENSORS = {
         name="Total dust collection count",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    f"consumable_{ATTR_CONSUMABLE_STATUS_MAIN_BRUSH_LEFT}": RoborockSensorDescription(
+    f"consumable_{ATTR_CONSUMABLE_STATUS_MAIN_BRUSH_REMAINING}": RoborockSensorDescription(
         native_unit_of_measurement=TIME_SECONDS,
         key=ConsumableField.MAIN_BRUSH_WORK_TIME,
-        value=lambda value: 10800000 - value,
+        value=lambda value: 1080000 - value,
         icon="mdi:brush",
         device_class=SensorDeviceClass.DURATION,
         parent_key=RoborockDevicePropField.CONSUMABLE,
-        name="Main brush left",
+        name="Main brush remaining",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    f"consumable_{ATTR_CONSUMABLE_STATUS_SIDE_BRUSH_LEFT}": RoborockSensorDescription(
+    f"consumable_{ATTR_CONSUMABLE_STATUS_SIDE_BRUSH_REMAINING}": RoborockSensorDescription(
         native_unit_of_measurement=TIME_SECONDS,
         key=ConsumableField.SIDE_BRUSH_WORK_TIME,
         value=lambda value: 720000 - value,
         icon="mdi:brush",
         device_class=SensorDeviceClass.DURATION,
         parent_key=RoborockDevicePropField.CONSUMABLE,
-        name="Side brush left",
+        name="Side brush remaining",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    f"consumable_{ATTR_CONSUMABLE_STATUS_FILTER_LEFT}": RoborockSensorDescription(
+    f"consumable_{ATTR_CONSUMABLE_STATUS_FILTER_REMAINING}": RoborockSensorDescription(
         native_unit_of_measurement=TIME_SECONDS,
         key=ConsumableField.FILTER_WORK_TIME,
         value=lambda value: 540000 - value,
         icon="mdi:air-filter",
         device_class=SensorDeviceClass.DURATION,
         parent_key=RoborockDevicePropField.CONSUMABLE,
-        name="Filter left",
+        name="Filter remaining",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    f"consumable_{ATTR_CONSUMABLE_STATUS_SENSOR_DIRTY_LEFT}": RoborockSensorDescription(
+    f"consumable_{ATTR_CONSUMABLE_STATUS_SENSOR_DIRTY_REMAINING}": RoborockSensorDescription(
         native_unit_of_measurement=TIME_SECONDS,
         key=ConsumableField.SENSOR_DIRTY_TIME,
         value=lambda value: 108000 - value,
         icon="mdi:eye-outline",
         device_class=SensorDeviceClass.DURATION,
         parent_key=RoborockDevicePropField.CONSUMABLE,
-        name="Sensor dirty left",
+        name="Sensor dirty remaining",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
 }

--- a/custom_components/roborock/sensor.py
+++ b/custom_components/roborock/sensor.py
@@ -103,7 +103,7 @@ VACUUM_SENSORS = {
     f"last_clean_{ATTR_LAST_CLEAN_AREA}": RoborockSensorDescription(
         native_unit_of_measurement=AREA_SQUARE_METERS,
         key=CleanRecordField.AREA,
-        value=lambda value: value / 1000000,
+        value=lambda value: round(value / 1000000, 1),
         icon="mdi:texture-box",
         parent_key=RoborockDevicePropField.LAST_CLEAN_RECORD,
         name="Last clean area",
@@ -122,7 +122,7 @@ VACUUM_SENSORS = {
         native_unit_of_measurement=AREA_SQUARE_METERS,
         icon="mdi:texture-box",
         key=StatusField.CLEAN_AREA,
-        value=lambda value: value / 1000000,
+        value=lambda value: round(value / 1000000, 1),
         parent_key=RoborockDevicePropField.STATUS,
         entity_category=EntityCategory.DIAGNOSTIC,
         name="Current clean area",

--- a/custom_components/roborock/sensor.py
+++ b/custom_components/roborock/sensor.py
@@ -139,7 +139,7 @@ VACUUM_SENSORS = {
     f"clean_history_{ATTR_CLEAN_SUMMARY_TOTAL_AREA}": RoborockSensorDescription(
         native_unit_of_measurement=AREA_SQUARE_METERS,
         key=CleanSummaryField.CLEAN_AREA,
-        value=lambda value: value / 1000000,
+        value=lambda value: round(value / 1000000, 1),
         icon="mdi:texture-box",
         parent_key=RoborockDevicePropField.CLEAN_SUMMARY,
         name="Total clean area",

--- a/custom_components/roborock/translations/en.json
+++ b/custom_components/roborock/translations/en.json
@@ -23,7 +23,9 @@
     "step": {
       "user": {
         "data": {
+          "binary_sensor": "Integrate mop & water box binary sensors",
           "camera": "Integrate map as camera",
+          "sensor": "Integrate status & summary sensors",
           "vacuum": "Integrate vacuum"
         }
       }

--- a/custom_components/roborock/vacuum.py
+++ b/custom_components/roborock/vacuum.py
@@ -355,7 +355,7 @@ class RoborockVacuum(RoborockCoordinatedEntity, StateVacuumEntity, ABC):
     @property
     def mop_intensity(self):
         """Return the mop intensity of the vacuum cleaner."""
-        mop_intensity = self._device_status.water_box_status
+        mop_intensity = self._device_status.water_box_mode
         return MOP_INTENSITY_CODES.get(mop_intensity)
 
     @property


### PR DESCRIPTION
**Changes:**

- Renamed sensors using the word "left" to "remaining" for clarity (no ambiguity with the direction left) and it matches the app verbiage. I realize this is more preference so no worries if you don't want to merge these.
- Round meters squared to one decimal place. Same comment as above.
- Convert "Current clean area" to meters squared.
- Fix "Main brush remaining" conversion (one extra zero).
- Fix mop intensity attribute.
- Add missing `binary_sensor` and `sensor` descriptions for config flow options (English only).
- Add doc strings to camera.py
- Renamed class `VacuumCamera` to `VacuumCameraMap`
- Added "Map" for `_attr_name` to `VacuumCameraMap`
- Added `mdi:map` for `attr_icon` to `VacuumCameraMap`

**Discussion:**

The reason for the renaming of the `VacuumCamera` class to `VacuumCameraMap` is because it better describes the class and maybe some day in the future we'll actually be able to access the vacuum camera. Same with adding the `Map` to `_attr_name`, it better describes what the entity actually is instead of just calling it the name of the vacuum which honestly made me think it was the actual camera on the vacuum itself (before I saw the image of the map).

For the config flow options, right now we're just making every platform type an option. Not sure if that's really necessary or desired. I think having the option to not add the map as a camera might be useful, but the user can just as easily disable the entities as desired.