### PR TITLE
Change carpet_map to Set for faster lookups

### DIFF
--- a/custom_components/roborock/common/image_handler.py
+++ b/custom_components/roborock/common/image_handler.py
@@ -1,6 +1,6 @@
 import logging
 import math
-from typing import Tuple, List, Dict, Callable
+from typing import Tuple, List, Dict, Callable, Set
 
 from PIL import Image, ImageDraw, ImageFont
 from PIL.Image import Image as ImageType
@@ -370,7 +370,7 @@ class ImageHandlerRoborock:
         image.data = Image.alpha_composite(image.data, layer)
 
     @staticmethod
-    def parse(raw_data: bytes, width: int, height: int, carpet_map: List[int], colors: Colors,
+    def parse(raw_data: bytes, width: int, height: int, carpet_map: Set[int], colors: Colors,
               image_config: ImageConfig) -> Tuple[ImageType, dict]:
         rooms = {}
         scale = image_config[CONF_SCALE]

--- a/custom_components/roborock/common/map_data.py
+++ b/custom_components/roborock/common/map_data.py
@@ -333,7 +333,7 @@ class MapData:
         self.no_go_areas: Optional[List[Area]] = None
         self.no_mopping_areas: Optional[List[Area]] = None
         self.no_carpet_areas: Optional[List[Area]] = None
-        self.carpet_map: Optional[List[int]] = []
+        self.carpet_map: Optional[Set[int]] = []
         self.obstacles: Optional[List[Obstacle]] = None
         self.ignored_obstacles: Optional[List[Obstacle]] = None
         self.obstacles_with_photo: Optional[List[Obstacle]] = None

--- a/custom_components/roborock/common/map_data_parser.py
+++ b/custom_components/roborock/common/map_data_parser.py
@@ -199,7 +199,7 @@ class MapDataParserRoborock:
         return room
 
     @staticmethod
-    def parse_image(block_data_length: int, block_header_length: int, data: bytes, header: bytes, carpet_map: List[int],
+    def parse_image(block_data_length: int, block_header_length: int, data: bytes, header: bytes, carpet_map: Set[int],
                     colors: Colors, image_config: ImageConfig) -> Tuple[ImageData, Dict[int, Room]]:
         image_size = block_data_length
         image_top = MapDataParserRoborock.get_int32(header, block_header_length - 16)
@@ -231,12 +231,12 @@ class MapDataParserRoborock:
                          image_config,
                          image, MapDataParserRoborock.map_to_image), rooms
     @staticmethod
-    def parse_carpet_map(data: bytes, image_config: ImageConfig) -> List[int]:
-        carpet_map = []
+    def parse_carpet_map(data: bytes, image_config: ImageConfig) -> Set[int]:
+        carpet_map = set()
 
         for i, v in enumerate(data):
             if v:
-                carpet_map.append(i)
+                carpet_map.add(i)
         return carpet_map
 
     @staticmethod


### PR DESCRIPTION
When drawing the carpet map a list was used to look up where carpet was found, which is rather slow.

Before:
```
carpet_map has 2996 elements
drawing 230x322 image took 7.0867 seconds
```

After:
```
carpet_map has 2996 elements
drawing 230x322 image took 0.4882 seconds
```

As it turns out doing 74060 lookups in a 2996 element list is slow 🤦 

Fixes #98 
