### PR TITLE
Update exception handling

### DIFF
--- a/custom_components/roborock/__init__.py
+++ b/custom_components/roborock/__init__.py
@@ -10,8 +10,9 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from custom_components.roborock.api.api import RoborockClient, RoborockMqttClient
-from .api.containers import Status, UserData, HomeData, CleanSummary
+from .api.api import RoborockClient, RoborockMqttClient
+from .api.containers import UserData, HomeData
+from .api.exceptions import RoborockException
 from .api.typing import RoborockDeviceInfo, RoborockDeviceProp
 from .const import CONF_ENTRY_USERNAME, CONF_USER_DATA, CONF_BASE_URL
 from .const import DOMAIN, PLATFORMS
@@ -129,19 +130,16 @@ class RoborockDataUpdateCoordinator(
         try:
             for device_id, _ in self.api.device_map.items():
                 device_prop = None
-                retries = 3
-                while not device_prop and retries > 0:
-                    device_prop = await self.api.get_prop(device_id)
-                    retries -= 1
+                device_prop = await self.api.get_prop(device_id)
                 if device_prop:
                     if device_id in self._devices_prop:
                         self._devices_prop[device_id].update(device_prop)
                     else:
                         self._devices_prop[device_id] = device_prop
             return self._devices_prop
-        except Exception as exception:
-            _LOGGER.exception(exception)
-            raise UpdateFailed(exception) from exception
+        except (TimeoutError, RoborockException) as ex:
+            _LOGGER.exception(ex)
+            raise UpdateFailed(ex) from ex
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/roborock/api/api.py
+++ b/custom_components/roborock/api/api.py
@@ -164,7 +164,7 @@ class RoborockMqttClient:
                             if isinstance(decrypted, list):
                                 decrypted = decrypted[0]
                             await queue.async_put((decrypted, None), timeout=QUEUE_TIMEOUT)
-            except RoborockException as ex:
+            except Exception as ex:
                 _LOGGER.exception(ex)
 
         @run_in_executor()

--- a/custom_components/roborock/api/exceptions.py
+++ b/custom_components/roborock/api/exceptions.py
@@ -1,0 +1,22 @@
+"""Roborock exceptions."""
+
+class RoborockException(Exception):
+    """Class for Roborock exceptions."""
+    def __init__(self, message):
+        self.message = message
+        super().__init__(self.message)
+
+
+class VacuumError(RoborockException):
+    """Class for vacuum errors."""
+    def __init__(self, code, message):
+        self.code = code
+        self.message = message
+        super().__init__(self.message)
+
+
+class CommandVacuumError(RoborockException):
+    """Class for command vacuum errors."""
+    def __init__(self, command: str, vacuum_error: VacuumError):
+        self.message = f"{command}: {str(vacuum_error)}"
+        super().__init__(self.message)

--- a/custom_components/roborock/api/exceptions.py
+++ b/custom_components/roborock/api/exceptions.py
@@ -2,9 +2,6 @@
 
 class RoborockException(Exception):
     """Class for Roborock exceptions."""
-    def __init__(self, message):
-        self.message = message
-        super().__init__(self.message)
 
 
 class VacuumError(RoborockException):
@@ -12,7 +9,7 @@ class VacuumError(RoborockException):
     def __init__(self, code, message):
         self.code = code
         self.message = message
-        super().__init__(self.message)
+        super().__init__()
 
 
 class CommandVacuumError(RoborockException):


### PR DESCRIPTION
Not sure if this is the preferred or ideal way to handle this but this is my attempt at preventing the Home Assistant logs from getting flooded with log messages. It seems even with a stable internet connection, timeouts from the `send_command` method are inevitable. From observing my logs over the past week, I don't see any case where trying to repeat the `send_command` again seems to help, but rather these timeouts appear to persist for anywhere from 30-90 seconds. Based on that, the following changes were made:

- Remove retrying `get_prop` 3 times after a failed attempt - just wait for the next `_async_update_data`
- Added new exceptions.py for all exception classes
- Change logger to debug for send_command timeouts
- Raise `TimeoutError` from `send_command` to be handled in the integration
- Change all base `Exception` to `RoborockException`

Definitely open to feedback or inputs on how to better handle this.