### PR TITLE
Remove debug exception and minor clean up

### DIFF
--- a/custom_components/roborock/api/api.py
+++ b/custom_components/roborock/api/api.py
@@ -300,7 +300,7 @@ class RoborockMqttClient(mqtt.Client):
             return response
         except (TimeoutError, CancelledError) as ex:
             _LOGGER.debug(f"Timeout after {QUEUE_TIMEOUT} seconds waiting for {method} response")
-            raise RoborockTimeout(ex) from ex
+            raise RoborockTimeout("Timeout waiting for response") from ex
         finally:
             del self._waiting_queue[request_id]
 

--- a/custom_components/roborock/api/api.py
+++ b/custom_components/roborock/api/api.py
@@ -213,7 +213,7 @@ class RoborockMqttClient(mqtt.Client):
         try:
             (_, err) = await connection_queue.async_get(timeout=QUEUE_TIMEOUT)
             if err:
-                raise err
+                raise RoborockException(err) from err
         except TimeoutError as ex:
             raise RoborockTimeout(f"Timeout after {QUEUE_TIMEOUT} seconds waiting for mqtt connection") from ex
         finally:
@@ -300,7 +300,7 @@ class RoborockMqttClient(mqtt.Client):
             return response
         except (TimeoutError, CancelledError) as ex:
             _LOGGER.debug(f"Timeout after {QUEUE_TIMEOUT} seconds waiting for {method} response")
-            raise RoborockTimeout("Timeout waiting for response") from ex
+            raise RoborockTimeout(f"Timeout after {QUEUE_TIMEOUT} waiting for response") from ex
         finally:
             del self._waiting_queue[request_id]
 

--- a/custom_components/roborock/api/api.py
+++ b/custom_components/roborock/api/api.py
@@ -215,7 +215,7 @@ class RoborockMqttClient(mqtt.Client):
             if err:
                 raise err
         except TimeoutError as ex:
-            raise RoborockException(f"Timeout after {QUEUE_TIMEOUT} seconds waiting for mqtt connection") from ex
+            raise RoborockTimeout(f"Timeout after {QUEUE_TIMEOUT} seconds waiting for mqtt connection") from ex
         finally:
             del self._waiting_queue[0]
 


### PR DESCRIPTION
Changes:
- Add description for `RoborockTimeout` in `RoborockMqttClient.send_command` to provide some information when we're catching it upstream.
- Replace `TimeoutError` with `RoborockTimeout` since `TimeoutError` exceptions are caught in the API and raise `RoborockTimeout`.
- Remove logger exception which [resolves seeing the traceback](https://github.com/humbertogontijo/homeassistant-roborock/issues/144#issuecomment-1382894940) for catching a known exception.
- Use "old" string formatting for logger per [HA dev docs](https://developers.home-assistant.io/docs/development_guidelines?_highlight=log#use-new-style-string-formatting).
- Raise `RoborockTimeout` instead for `TimeoutError` in `RoborockMqttClient.connect`.
- Add some missing doc strings.
- Removed unused import `HomeData`.