### PR TITLE
fix for creating NetworkInfo dataclass

### DIFF
--- a/custom_components/roborock/__init__.py
+++ b/custom_components/roborock/__init__.py
@@ -181,7 +181,7 @@ async def remove_entry_key(entry, hass, key):
 async def get_local_devices_info(cloud_client: RoborockMqttClient, devices_info: dict[str, RoborockHassDeviceInfo]):
     localdevices_info: dict[str, RoborockLocalDeviceInfo] = {}
     for device_id, device_info in devices_info.items():
-        network_info = NetworkInfo(
+        network_info = NetworkInfo.from_dict(
             await cloud_client.send_command(
                 device_id, RoborockCommand.GET_NETWORK_INFO
             )


### PR DESCRIPTION
Small fix for creating `NetworkInfo` dataclass instance. 

As a side note, awesome work on figuring out the local access. I realize this is all still a work in progress but I just started messing with this latest version of the integration with python-roborock 0.6.0 and was having issues getting the local API to work until I made this change.