### PR TITLE
use api get_networking method

### DIFF
--- a/custom_components/roborock/__init__.py
+++ b/custom_components/roborock/__init__.py
@@ -141,14 +141,13 @@ async def remove_entry_key(entry, hass, key):
     )
 
 
-async def get_local_devices_info(cloud_client: RoborockMqttClient, devices_info: dict[str, RoborockHassDeviceInfo]):
+async def get_local_devices_info(
+    cloud_client: RoborockMqttClient, devices_info: dict[str, RoborockHassDeviceInfo]
+):
+    """Get local device info."""
     localdevices_info: dict[str, RoborockLocalDeviceInfo] = {}
     for device_id, device_info in devices_info.items():
-        network_info = NetworkInfo.from_dict(
-            await cloud_client.send_command(
-                device_id, RoborockCommand.GET_NETWORK_INFO
-            )
-        )
+        network_info = await cloud_client.get_networking(device_id)
         localdevices_info[device_id] = RoborockLocalDeviceInfo(
             device=device_info.device,
             network_info=network_info


### PR DESCRIPTION
I just realized there's actually a `get_networking` method in `RoborockClient`, so this updates the integration to use that instead of calling `send_command`. API will handle any exceptions as well.