### PR TITLE
add functionality to reset consumables w button

### DIFF
--- a/custom_components/roborock/button.py
+++ b/custom_components/roborock/button.py
@@ -1,0 +1,103 @@
+from dataclasses import dataclass
+from .coordinator import RoborockDataUpdateCoordinator
+from .roborock_typing import RoborockHassDeviceInfo
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util import slugify
+from .device import RoborockCoordinatedEntity
+from homeassistant.components.button import (
+    ButtonDeviceClass,
+    ButtonEntity,
+    ButtonEntityDescription,
+)
+from roborock.typing import RoborockCommand
+from .const import DOMAIN
+
+
+@dataclass
+class RoborockButtonDescriptionMixin:
+    command: RoborockCommand
+    param: list | dict | None
+
+
+@dataclass
+class RoborockButtonDescription(
+    ButtonEntityDescription, RoborockButtonDescriptionMixin
+):
+    """Describes a Roborock Button"""
+
+
+CONSUMABLE_BUTTON_DESCRIPTIONS = [
+    RoborockButtonDescription(
+        key="consumable_reset_sensor",
+        device_class=ButtonDeviceClass.UPDATE,
+        translation_key="reset_sensor_consumable",
+        name="Reset sensor consumable",
+        command=RoborockCommand.RESET_CONSUMABLE,
+        param=["sensor_dirty_time"],
+    ),
+    RoborockButtonDescription(
+        key="consumable_reset_filter",
+        device_class=ButtonDeviceClass.UPDATE,
+        translation_key="reset_filter_consumable",
+        name="Reset filter consumable",
+        command=RoborockCommand.RESET_CONSUMABLE,
+        param=["filter_work_time"],
+    ),
+    RoborockButtonDescription(
+        key="consumable_reset_side_brush",
+        device_class=ButtonDeviceClass.UPDATE,
+        translation_key="reset_side_brush_consumable",
+        name="Reset side brush consumable",
+        command=RoborockCommand.RESET_CONSUMABLE,
+        param=["side_brush_work_time"],
+    ),
+    RoborockButtonDescription(
+        key="consumable_reset_main_brush",
+        device_class=ButtonDeviceClass.UPDATE,
+        translation_key="reset_main_brush_consumable",
+        name="Reset main brush consumable",
+        command=RoborockCommand.RESET_CONSUMABLE,
+        param=["main_brush_work_time"],
+    ),
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Roborock button platform."""
+
+    coordinator: RoborockDataUpdateCoordinator = hass.data[DOMAIN][
+        config_entry.entry_id
+    ]
+    async_add_entities(
+        RoborockButtonEntity(
+            f"{description.key}_{slugify(device_id)}",
+            device_info,
+            coordinator,
+            description,
+        )
+        for device_id, device_info in coordinator.devices_info.items()
+        for description in CONSUMABLE_BUTTON_DESCRIPTIONS
+    )
+
+
+class RoborockButtonEntity(RoborockCoordinatedEntity, ButtonEntity):
+    entity_description: RoborockButtonDescription
+
+    def __init__(
+        self,
+        unique_id: str,
+        device_info: RoborockHassDeviceInfo,
+        coordinator: RoborockDataUpdateCoordinator,
+        entity_description: RoborockButtonDescription,
+    ) -> None:
+        super().__init__(device_info, coordinator, unique_id)
+        self.entity_description = entity_description
+
+    async def async_press(self) -> None:
+        await self.send(RoborockCommand.RESET_CONSUMABLE, self.entity_description.param)

--- a/custom_components/roborock/const.py
+++ b/custom_components/roborock/const.py
@@ -4,7 +4,7 @@ from homeassistant.components.camera import DOMAIN as CAMERA_DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.vacuum import DOMAIN as VACUUM_DOMAIN
 from homeassistant.components.select import DOMAIN as SELECT_DOMAIN
-
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN
 DOMAIN = "roborock"
 CONF_ENTRY_USERNAME = "username"
 CONF_ENTRY_CODE = "code"
@@ -19,7 +19,7 @@ BINARY_SENSOR = BINARY_SENSOR_DOMAIN
 CAMERA = CAMERA_DOMAIN
 SENSOR = SENSOR_DOMAIN
 VACUUM = VACUUM_DOMAIN
-PLATFORMS = [VACUUM, CAMERA, SENSOR, BINARY_SENSOR, SELECT_DOMAIN]
+PLATFORMS = [VACUUM, CAMERA, SENSOR, BINARY_SENSOR, SELECT_DOMAIN, BUTTON_DOMAIN]
 
 ROCKROBO_V1 = "rockrobo.vacuum.v1"
 ROCKROBO_S4 = "roborock.vacuum.s4"

--- a/custom_components/roborock/manifest.json
+++ b/custom_components/roborock/manifest.json
@@ -14,7 +14,7 @@
     "roborock"
   ],
   "requirements": [
-    "python-roborock==0.7.5"
+    "python-roborock==0.7.6"
   ],
   "version": "1.0.0"
 }

--- a/custom_components/roborock/translations/da.json
+++ b/custom_components/roborock/translations/da.json
@@ -74,6 +74,20 @@
     }
   },
   "entity": {
+    "button": {
+      "reset_sensor_consumable": {
+        "name": "Reset sensor consumable"
+      },
+      "reset_filter_consumable": {
+        "name": "Reset filter consumable"
+      },
+      "reset_side_brush_consumable": {
+        "name": "Reset side brush consumable"
+      },
+      "reset_main_brush_consumable": {
+        "name": "Reset main brush consumable"
+      }
+    },
     "sensor": {
       "current_error": {
         "name": "Nuværende fejl",

--- a/custom_components/roborock/translations/de.json
+++ b/custom_components/roborock/translations/de.json
@@ -72,6 +72,20 @@
     }
   },
   "entity": {
+    "button": {
+      "reset_sensor_consumable": {
+        "name": "Reset sensor consumable"
+      },
+      "reset_filter_consumable": {
+        "name": "Reset filter consumable"
+      },
+      "reset_side_brush_consumable": {
+        "name": "Reset side brush consumable"
+      },
+      "reset_main_brush_consumable": {
+        "name": "Reset main brush consumable"
+      }
+    },
     "sensor": {
       "current_error": {
         "name": "Current error",

--- a/custom_components/roborock/translations/en.json
+++ b/custom_components/roborock/translations/en.json
@@ -74,6 +74,20 @@
     }
   },
   "entity": {
+    "button": {
+      "reset_sensor_consumable": {
+        "name": "Reset sensor consumable"
+      },
+      "reset_filter_consumable": {
+        "name": "Reset filter consumable"
+      },
+      "reset_side_brush_consumable": {
+        "name": "Reset side brush consumable"
+      },
+      "reset_main_brush_consumable": {
+        "name": "Reset main brush consumable"
+      }
+    },
     "sensor": {
       "current_error": {
         "name": "Current error",

--- a/custom_components/roborock/translations/fr.json
+++ b/custom_components/roborock/translations/fr.json
@@ -72,6 +72,20 @@
     }
   },
   "entity": {
+    "button": {
+      "reset_sensor_consumable": {
+        "name": "Reset sensor consumable"
+      },
+      "reset_filter_consumable": {
+        "name": "Reset filter consumable"
+      },
+      "reset_side_brush_consumable": {
+        "name": "Reset side brush consumable"
+      },
+      "reset_main_brush_consumable": {
+        "name": "Reset main brush consumable"
+      }
+    },
     "sensor": {
       "current_error": {
         "name": "Current error",

--- a/custom_components/roborock/translations/it.json
+++ b/custom_components/roborock/translations/it.json
@@ -74,6 +74,20 @@
     }
   },
   "entity": {
+    "button": {
+      "reset_sensor_consumable": {
+        "name": "Reset sensor consumable"
+      },
+      "reset_filter_consumable": {
+        "name": "Reset filter consumable"
+      },
+      "reset_side_brush_consumable": {
+        "name": "Reset side brush consumable"
+      },
+      "reset_main_brush_consumable": {
+        "name": "Reset main brush consumable"
+      }
+    },
     "sensor": {
       "current_error": {
         "name": "Errore corrente",

--- a/custom_components/roborock/translations/nl.json
+++ b/custom_components/roborock/translations/nl.json
@@ -72,6 +72,20 @@
     }
   },
   "entity": {
+    "button": {
+      "reset_sensor_consumable": {
+        "name": "Reset sensor consumable"
+      },
+      "reset_filter_consumable": {
+        "name": "Reset filter consumable"
+      },
+      "reset_side_brush_consumable": {
+        "name": "Reset side brush consumable"
+      },
+      "reset_main_brush_consumable": {
+        "name": "Reset main brush consumable"
+      }
+    },
     "sensor": {
       "current_error": {
         "name": "Current error",

--- a/custom_components/roborock/translations/no.json
+++ b/custom_components/roborock/translations/no.json
@@ -72,6 +72,20 @@
     }
   },
   "entity": {
+    "button": {
+      "reset_sensor_consumable": {
+        "name": "Reset sensor consumable"
+      },
+      "reset_filter_consumable": {
+        "name": "Reset filter consumable"
+      },
+      "reset_side_brush_consumable": {
+        "name": "Reset side brush consumable"
+      },
+      "reset_main_brush_consumable": {
+        "name": "Reset main brush consumable"
+      }
+    },
     "sensor": {
       "current_error": {
         "name": "Current error",

--- a/custom_components/roborock/translations/pl.json
+++ b/custom_components/roborock/translations/pl.json
@@ -72,6 +72,20 @@
     }
   },
   "entity": {
+    "button": {
+      "reset_sensor_consumable": {
+        "name": "Reset sensor consumable"
+      },
+      "reset_filter_consumable": {
+        "name": "Reset filter consumable"
+      },
+      "reset_side_brush_consumable": {
+        "name": "Reset side brush consumable"
+      },
+      "reset_main_brush_consumable": {
+        "name": "Reset main brush consumable"
+      }
+    },
     "sensor": {
       "current_error": {
         "name": "Current error",

--- a/custom_components/roborock/translations/pt-BR.json
+++ b/custom_components/roborock/translations/pt-BR.json
@@ -72,6 +72,20 @@
     }
   },
   "entity": {
+    "button": {
+      "reset_sensor_consumable": {
+        "name": "Reset sensor consumable"
+      },
+      "reset_filter_consumable": {
+        "name": "Reset filter consumable"
+      },
+      "reset_side_brush_consumable": {
+        "name": "Reset side brush consumable"
+      },
+      "reset_main_brush_consumable": {
+        "name": "Reset main brush consumable"
+      }
+    },
     "sensor": {
       "current_error": {
         "name": "Erro atual",

--- a/custom_components/roborock/translations/pt.json
+++ b/custom_components/roborock/translations/pt.json
@@ -72,6 +72,20 @@
     }
   },
   "entity": {
+    "button": {
+      "reset_sensor_consumable": {
+        "name": "Reset sensor consumable"
+      },
+      "reset_filter_consumable": {
+        "name": "Reset filter consumable"
+      },
+      "reset_side_brush_consumable": {
+        "name": "Reset side brush consumable"
+      },
+      "reset_main_brush_consumable": {
+        "name": "Reset main brush consumable"
+      }
+    },
     "sensor": {
       "current_error": {
         "name": "Erro atual",

--- a/custom_components/roborock/translations/ru.json
+++ b/custom_components/roborock/translations/ru.json
@@ -72,6 +72,20 @@
     }
   },
   "entity": {
+    "button": {
+      "reset_sensor_consumable": {
+        "name": "Reset sensor consumable"
+      },
+      "reset_filter_consumable": {
+        "name": "Reset filter consumable"
+      },
+      "reset_side_brush_consumable": {
+        "name": "Reset side brush consumable"
+      },
+      "reset_main_brush_consumable": {
+        "name": "Reset main brush consumable"
+      }
+    },
     "sensor": {
       "current_error": {
         "name": "Current error",

--- a/custom_components/roborock/translations/sv.json
+++ b/custom_components/roborock/translations/sv.json
@@ -72,6 +72,20 @@
     }
   },
   "entity": {
+    "button": {
+      "reset_sensor_consumable": {
+        "name": "Reset sensor consumable"
+      },
+      "reset_filter_consumable": {
+        "name": "Reset filter consumable"
+      },
+      "reset_side_brush_consumable": {
+        "name": "Reset side brush consumable"
+      },
+      "reset_main_brush_consumable": {
+        "name": "Reset main brush consumable"
+      }
+    },
     "sensor": {
       "current_error": {
         "name": "Current error",


### PR DESCRIPTION
This is working online only right now. The prefix for reset consumables is wrong, and I am without my mac right now so I can't connect my phone to reverse engineer the prefix. If you are able to - then this should be good to go