### PR TITLE
feat: add missing key, rename confusing

### DIFF
--- a/custom_components/roborock/translations/en.json
+++ b/custom_components/roborock/translations/en.json
@@ -204,8 +204,9 @@
     },
     "select": {
       "mop_mode": {
-        "name": "Mop mode",
+        "name": "Route",
         "state": {
+          "fast": "Fast",
           "standard": "Standard",
           "deep": "Deep",
           "deep_plus": "Deep+",
@@ -216,9 +217,12 @@
         "name": "Mop intensity",
         "state": {
           "off": "Off",
+          "low": "Low",
           "mild": "Mild",
           "moderate": "Moderate",
+          "medium": "Medium",
           "intense": "Intense",
+          "high": "High",
           "custom": "Custom"
         }
       }

--- a/custom_components/roborock/translations/fr.json
+++ b/custom_components/roborock/translations/fr.json
@@ -212,8 +212,9 @@
     },
     "select": {
       "mop_mode": {
-        "name": "Parcours de lavage de sol",
+        "name": "Parcours",
         "state": {
+          "fast": "Rapide",
           "standard": "Standard",
           "deep": "Approfondi",
           "deep_plus": "Approfondi+",
@@ -225,10 +226,18 @@
         "state": {
           "off": "Aucun",
           "mild": "Faible",
+          "low": "Faible",
           "moderate": "Moyen",
+          "medium": "Moyen",
           "intense": "Elevé",
+          "high": "Elevé",
           "custom": "Personnalisé"
         }
+      }
+    },
+    "number": {
+      "sound_volume": {
+        "name": "Volume"
       }
     },
     "vacuum": {


### PR DESCRIPTION
Translation files : 

- Renaming confusing "mop_mode" to "route" to match Roborock app's denomination (both in FR/EN)
- Adding missing "Fast" key to translation in route.
- Adding Low/Medium/High missing key for Mop intensity when using some robots
- Adding "sound_volume" translation key for french