### PR TITLE
Added: Roborock G10 Variant- `roborock.vacuum.a30`

### DIFF
--- a/custom_components/roborock/const.py
+++ b/custom_components/roborock/const.py
@@ -51,6 +51,7 @@ ROCKROBO_Q5 = "roborock.vacuum.a34"
 ROCKROBO_Q7_MAX = "roborock.vacuum.a38"
 ROCKROBO_G10S = "roborock.vacuum.a46"
 ROCKROBO_G10 = "roborock.vacuum.a29"
+ROCKROBO_G10_SG = "roborock.vacuum.a30" # Variant of the G10, has similar features as S7
 ROCKROBO_S7 = "roborock.vacuum.a15"
 ROCKROBO_S6_MAXV = "roborock.vacuum.a10"
 ROCKROBO_E2 = "roborock.vacuum.e2"
@@ -69,10 +70,12 @@ MODELS_VACUUM_WITH_MOP = [
     ROCKROBO_S7,
     ROCKROBO_S7_MAXV,
     ROCKROBO_P10,
+    ROCKROBO_G10_SG,
 ]
 MODELS_VACUUM_WITH_SEPARATE_MOP = [
     ROCKROBO_S7,
     ROCKROBO_S7_MAXV,
+    ROCKROBO_G10_SG,
 ]
 
 MINIMAL_IMAGE_WIDTH = 20


### PR DESCRIPTION
https://home.miot-spec.com/spec/roborock.vacuum.a30

<details>
<summary>Miiot details</summary>

```json
{
      "did": <redacted>,
      "uid": <redacted>,
      "token": <redacted>,
      "name": "Roborock G10",
      "pid": 0,
      "localip": <redacted>,
      "mac": <redacted>,
      "ssid": <redacted>,
      "bssid": <redacted>,
      "rssi": -37,
      "longitude": "0.00000000",
      "latitude": "0.00000000",
      "show_mode": 1,
      "model": "roborock.vacuum.a30",
      "permitLevel": 16,
      "isOnline": false,
      "spec_type": "urn:miot-spec-v2:device:vacuum:0000A006:roborock-a30:1",
      "extra": {
        "isSetPincode": 0,
        "pincodeType": 0,
        "fw_version": "4.3.5_1292",
        "isSubGroup": false,
        "showGroupMember": false,
        "split": {}
      },
      "orderTime": 1672797489,
      "freqFlag": true,
      "hide_mode": 0,
      "last_online": 1698738321,
      "comFlag": 129
}
```

</details>