### PR TITLE
Change method for updating HA state

### DIFF
--- a/custom_components/roborock/device.py
+++ b/custom_components/roborock/device.py
@@ -126,5 +126,5 @@ class RoborockCoordinatedEntity(RoborockEntity, CoordinatorEntity[RoborockDataUp
         else:
             self.coordinator.device_info.props.consumable = value
         self.coordinator.data = self.coordinator.device_info.props
-        self.async_write_ha_state()
+        self.schedule_update_ha_state()
 


### PR DESCRIPTION
See https://developers.home-assistant.io/docs/asyncio_thread_safety/#async_write_ha_state.

Fix #634 and #641 that mention warning in HA logs regarding method change.