### PR TITLE
Fix warning introduced in HA 2024.7

### DIFF
--- a/custom_components/roborock/__init__.py
+++ b/custom_components/roborock/__init__.py
@@ -148,10 +148,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # Don't start if no coordinators succeeded.
         raise ConfigEntryNotReady("There are no devices that can currently be reached.")
 
-    for platform in platforms:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, platform)
-        )
+    await hass.config_entries.async_forward_entry_setups(entry, platforms)
 
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
     return True


### PR DESCRIPTION
Fix warning introduced in HA 2024.7.
Please see https://developers.home-assistant.io/blog/2024/06/12/async_forward_entry_setups/ for more details.