### PR TITLE
Fix blocking call error due to blocking function call

### DIFF
--- a/custom_components/roborock/__init__.py
+++ b/custom_components/roborock/__init__.py
@@ -100,7 +100,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 model=product.model,
             )
 
-            map_client = RoborockMqttClient(user_data, device_info)
+            map_client = await hass.async_add_executor_job(RoborockMqttClient, user_data, device_info)
 
             if not cloud_integration:
                 network = device_network.get(device_id)


### PR DESCRIPTION
This PR fixes issue #663.

Call of function RoborockMqttClient is a blocking call.