### PR TITLE
Area_square_meters deprecation

### DIFF
--- a/custom_components/roborock/sensor.py
+++ b/custom_components/roborock/sensor.py
@@ -16,7 +16,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import UnitOfArea.SQUARE_METERS, PERCENTAGE, UnitOfTime
+from homeassistant.const import UnitOfArea, PERCENTAGE, UnitOfTime
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -130,7 +130,7 @@ VACUUM_SENSORS = {
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     f"current_{ATTR_STATUS_CLEAN_AREA}": RoborockSensorDescription(
-        native_unit_of_measurement=AREA_SQUARE_METERS,
+        native_unit_of_measurement=UnitOfArea.SQUARE_METERS,
         icon="mdi:texture-box",
         key="clean_area",
         value=lambda value, _: round(value / 1000000, 1),
@@ -174,7 +174,7 @@ VACUUM_SENSORS = {
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     f"clean_history_{ATTR_CLEAN_SUMMARY_TOTAL_AREA}": RoborockSensorDescription(
-        native_unit_of_measurement=AREA_SQUARE_METERS,
+        native_unit_of_measurement=UnitOfArea.SQUARE_METERS,
         key="clean_area",
         value=lambda value, _: round(value / 1000000, 1),
         icon="mdi:texture-box",

--- a/custom_components/roborock/sensor.py
+++ b/custom_components/roborock/sensor.py
@@ -16,7 +16,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import AREA_SQUARE_METERS, PERCENTAGE, UnitOfTime
+from homeassistant.const import UnitOfArea.SQUARE_METERS, PERCENTAGE, UnitOfTime
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -100,7 +100,7 @@ VACUUM_SENSORS = {
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     f"last_clean_{ATTR_LAST_CLEAN_AREA}": RoborockSensorDescription(
-        native_unit_of_measurement=AREA_SQUARE_METERS,
+        native_unit_of_measurement=UnitOfArea.SQUARE_METERS,
         key="area",
         value=lambda value, _: round(value / 1000000, 1),
         icon="mdi:texture-box",


### PR DESCRIPTION
I created this to resolve #673, area_square_meters is being deprecated and it's recommended to replace it with UnitOfArea.SQUARE_METERS
I changed the instances in sensor.py to reflect this change, and tested on my own setup with an S7