### PR TITLE
adapt to v1 api of python-roborock

### DIFF
--- a/custom_components/roborock/__init__.py
+++ b/custom_components/roborock/__init__.py
@@ -8,9 +8,9 @@ from pathlib import Path
 
 from roborock import RoborockException
 from roborock.web_api import RoborockApiClient
-from roborock.cloud_api import RoborockMqttClient
+from roborock.version_1_apis import RoborockMqttClientV1 as RoborockMqttClient
+from roborock.version_1_apis import RoborockLocalClientV1 as RoborockLocalClient
 from roborock.containers import HomeData, HomeDataProduct, UserData
-from roborock.local_api import RoborockLocalClient
 from roborock.protocol import RoborockProtocol
 from slugify import slugify
 

--- a/custom_components/roborock/calendar.py
+++ b/custom_components/roborock/calendar.py
@@ -26,7 +26,7 @@ from ical.store import EventStore, EventStoreError
 from ical.types import Frequency, Range, Recur, RecurrenceId, Weekday
 from pydantic import ValidationError
 from roborock import RoborockBaseTimer, RoborockCommand, RoborockException, ServerTimer
-from roborock.api import RoborockClient
+from roborock.version_1_apis import RoborockClientV1 as RoborockClient
 from roborock.command_cache import CacheableAttribute
 
 from . import EntryData

--- a/custom_components/roborock/coordinator.py
+++ b/custom_components/roborock/coordinator.py
@@ -7,8 +7,8 @@ from datetime import timedelta
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-from roborock.api import RoborockClient
-from roborock.cloud_api import RoborockMqttClient
+from roborock.version_1_apis import RoborockClientV1 as RoborockClient
+from roborock.version_1_apis import RoborockMqttClientV1 as RoborockMqttClient
 from roborock.containers import HomeDataRoom, MultiMapsList, RoborockBase
 from roborock.exceptions import RoborockException
 

--- a/custom_components/roborock/device.py
+++ b/custom_components/roborock/device.py
@@ -7,7 +7,8 @@ from typing import Optional
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import DeviceInfo, Entity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from roborock.api import RT, RoborockClient
+from roborock.version_1_apis import RoborockClientV1 as RoborockClient
+from roborock.version_1_apis.roborock_client_v1 import RT
 from roborock.containers import Status, Consumable
 from roborock.exceptions import RoborockException
 from roborock.roborock_typing import RoborockCommand

--- a/custom_components/roborock/manifest.json
+++ b/custom_components/roborock/manifest.json
@@ -14,7 +14,7 @@
     "roborock"
   ],
   "requirements": [
-    "python-roborock==0.40.0",
+    "python-roborock==2.12.1",
     "ical==7.0.3",
     "dacite==1.8.0"
   ],

--- a/custom_components/roborock/number.py
+++ b/custom_components/roborock/number.py
@@ -11,7 +11,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import slugify
-from roborock.api import AttributeCache
+from roborock.version_1_apis import AttributeCache
 from roborock.command_cache import CacheableAttribute
 
 from . import EntryData

--- a/custom_components/roborock/switch.py
+++ b/custom_components/roborock/switch.py
@@ -13,7 +13,8 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import slugify
-from roborock.api import AttributeCache, RoborockClient
+from roborock.version_1_apis import AttributeCache
+from roborock.version_1_apis import RoborockClientV1 as RoborockClient
 from roborock.command_cache import CacheableAttribute
 
 from . import EntryData, RoborockHassDeviceInfo

--- a/custom_components/roborock/time.py
+++ b/custom_components/roborock/time.py
@@ -8,7 +8,9 @@ from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from typing import Any
 
-from roborock.api import AttributeCache, RoborockClient
+
+from roborock.version_1_apis import AttributeCache
+from roborock.version_1_apis import RoborockClientV1 as RoborockClient
 from roborock.command_cache import CacheableAttribute
 
 from homeassistant.components.time import TimeEntity, TimeEntityDescription


### PR DESCRIPTION
Update code to adapt to the new way of using the api of python-roborock>=1.0.0
Fix the problem with Home Assistant 2025.3.0 (due to paho-mqtt need to be 2.1.0, which is incompatible with python-roborock==0.40.0)